### PR TITLE
Change Laravel Permission config to avoid to log alert while running tests

### DIFF
--- a/config/laravel-permission.php
+++ b/config/laravel-permission.php
@@ -130,4 +130,13 @@ return [
 
     ],
 
+    /*
+     * By default we'll make an entry in the application log when the permissions
+     * could not be loaded. Normally this only occurs while installing the packages.
+     *
+     * If for some reason you want to disable that logging, set this value to false.
+     */
+
+    'log_registration_exception' => env('APP_ENV') !== 'testing',
+
 ];


### PR DESCRIPTION
A simple fix to avoid Laravel log file to be filled with _"Could not register permissions..."_ alert messages.

This is because for each test, an application instance is created **before** running use trait tasks (_database migration, etc..._). Each time application instance is created, the Spatie laravel-permission service provider attempt to register permissions. (_and since database is not migrated yet, it fail and write an exception message in log file_).

To avoid this behaviour, the laravel-permission provide the `log_registration_exception` boolean option : theses changes simply set this option to false if APP_ENV equals "testing".



