### PR TITLE
Make UUID fillable at entity creation using UUID scope trait

### DIFF
--- a/app/Support/UuidScopeTrait.php
+++ b/app/Support/UuidScopeTrait.php
@@ -27,7 +27,9 @@ trait UuidScopeTrait
         parent::boot();
 
         static::creating(function ($model) {
-            $model->uuid = Uuid::generate()->string;
+            if (empty($model->uuid)) {
+                $model->uuid = Uuid::generate()->string;
+            }
         });
     }
 }

--- a/tests/Unit/Entities/RoleTest.php
+++ b/tests/Unit/Entities/RoleTest.php
@@ -51,4 +51,14 @@ class RoleTest extends TestCase
         });
     }
 
+    function test_it_can_fill_uuid_at_creation()
+    {
+        $uuid = '84e28c10-8991-11e7-ad89-056674746d73';
+
+        $roleNotFilled = factory(Role::class)->create();
+        $this->assertNotEquals($uuid, $roleNotFilled->uuid);
+
+        $roleFilled = factory(Role::class)->create(['uuid' => $uuid]);
+        $this->assertEquals($uuid, $roleFilled->uuid);
+    }
 }


### PR DESCRIPTION
It fixe a bug with UUID scope trait when providing `uuid` attribute at entity creation.

Example case :

```php
$fixedUuid = '84e28c10-8991-11e7-ad89-056674746d73';
$role = Role::firstOrCreate(['name' =>'John', 'uuid' => $fixedUuid]);
```
Current code generate a new uuid at creation even if you provide one.
(_with fix, it properly set the provided uuid_).


