### PR TITLE
fix: adds missing 'deleted_at' date mutator in User entity

### DIFF
--- a/app/Entities/User.php
+++ b/app/Entities/User.php
@@ -20,6 +20,15 @@ class User extends Authenticatable
     }
 
     /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'deleted_at',
+    ];
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array


### PR DESCRIPTION
Adds missing date mutator for soft delete `deleted_at` column, as specified in [documentation](https://laravel.com/docs/5.4/eloquent#soft-deleting).
 Currently, if you retrieve a user from database, only `created_at` and `updated_at` are auto-mutated to date. (_deleted_at is left as string_).