### PR TITLE
fix: change uuid scope trait boot method

### DIFF
--- a/app/Support/UuidScopeTrait.php
+++ b/app/Support/UuidScopeTrait.php
@@ -20,12 +20,12 @@ trait UuidScopeTrait
     }
 
     /**
-     * Boot function from laravel.
+     * Boot the uuid scope trait for a model.
+     *
+     * @return void
      */
-    protected static function boot()
+    protected static function bootUuidScopeTrait()
     {
-        parent::boot();
-
         static::creating(function ($model) {
             if (empty($model->uuid)) {
                 $model->uuid = Uuid::generate()->string;


### PR DESCRIPTION
This fix allow developer to use static `boot()` method in models without conflicting with the uuid scope trait.

To handle this issue, Laravel framework, while booting all model traits, check for the `bootTraitClassName` method and execute it if exists.
